### PR TITLE
Private (set) var Swift 6 compile error fix

### DIFF
--- a/Sources/JsonPolymorphicMacroMacros/JsonPolymorphicMacroMacro.swift
+++ b/Sources/JsonPolymorphicMacroMacros/JsonPolymorphicMacroMacro.swift
@@ -60,7 +60,7 @@ public struct JsonPolymorphicMacro: MemberMacro {
             var polyAccessType = "let"
             if isDummyArray {
                 polyDataType = "[\(dataGenericType)]"
-                polyAccessType = "private (set) var"
+                polyAccessType = "private(set) var"
             }
             let polymorphicVariableSet = "\(polyAccessType) \(polyParamName): \(polyDataType)?"
             codeBlockGen.append(DeclSyntax(stringLiteral: polymorphicVariableSet))

--- a/Tests/JsonPolymorphicMacroTests/JsonPolymorphicMacroSameLevelTest.swift
+++ b/Tests/JsonPolymorphicMacroTests/JsonPolymorphicMacroSameLevelTest.swift
@@ -151,7 +151,7 @@ final class JsonPolymorphicMacroSameLevelTest: XCTestCase {
 
 
 
-                private (set) var selections: [BetslipBaseState]?
+                private(set) var selections: [BetslipBaseState]?
 
                 enum CodingKeys: String, CodingKey {
                     case changesDetected
@@ -222,9 +222,9 @@ final class JsonPolymorphicMacroSameLevelTest: XCTestCase {
 
 
 
-                private (set) var selections: [BetslipBaseSelection]?
+                private(set) var selections: [BetslipBaseSelection]?
 
-                private (set) var combinations: [BetslipBaseCombination]?
+                private(set) var combinations: [BetslipBaseCombination]?
 
                 enum CodingKeys: String, CodingKey {
                     case changesDetected
@@ -313,7 +313,7 @@ final class JsonPolymorphicMacroSameLevelTest: XCTestCase {
 
                 let selections: BetslipBaseSelection?
 
-                private (set) var combinations: [BetslipBaseCombination]?
+                private(set) var combinations: [BetslipBaseCombination]?
 
                 enum CodingKeys: String, CodingKey {
                     case changesDetected
@@ -389,7 +389,7 @@ final class JsonPolymorphicMacroSameLevelTest: XCTestCase {
 
 
 
-                private (set) var selections: [BetslipBaseSelection]?
+                private(set) var selections: [BetslipBaseSelection]?
 
                 let type: String?
 
@@ -461,7 +461,7 @@ final class JsonPolymorphicMacroSameLevelTest: XCTestCase {
 
 
 
-                private (set) var selections: [BetslipBaseSelection]?
+                private(set) var selections: [BetslipBaseSelection]?
 
                 let type: String?
 


### PR DESCRIPTION
In Swift 6 the `private (set) var` gives a compile error with a warning `Extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode`.

To fix this we can delete the space before the (set)